### PR TITLE
支持音频设备选择和获取可用音频设备列表

### DIFF
--- a/AudioDevice.cs
+++ b/AudioDevice.cs
@@ -1,0 +1,7 @@
+﻿namespace EdgeTTS;
+
+public class AudioDevice(int id, string name)
+{
+    public int Id { get; } = id;
+    public string Name { get; } = name;
+}

--- a/EdgeTTSSettings.cs
+++ b/EdgeTTSSettings.cs
@@ -2,10 +2,11 @@ namespace EdgeTTS;
 
 public class EdgeTTSSettings
 {
-    public int    Speed  { get; set; } = 100;
-    public int    Pitch  { get; set; } = 100;
-    public int    Volume { get; set; } = 100;
-    public string Voice  { get; set; } = "zh-CN-YunyangNeural";
+    public int    AudioDeviceId { get; set; } = 0;
+    public int    Speed         { get; set; } = 100;
+    public int    Pitch         { get; set; } = 100;
+    public int    Volume        { get; set; } = 100;
+    public string Voice         { get; set; } = "zh-CN-YunyangNeural";
 
     public Dictionary<string, string> PhonemeReplacements { get; set; } = new()
     {
@@ -13,6 +14,6 @@ public class EdgeTTSSettings
         ["歐米茄"] = "歐米加",
     };
 
-    public override string ToString() =>
-        $"{nameof(Speed)}: {Speed}, {nameof(Pitch)}: {Pitch}, {nameof(Volume)}: {Volume}, {nameof(Voice)}: {Voice}";
+    public override string ToString() => 
+        $"{nameof(AudioDeviceId)}: {AudioDeviceId}, {nameof(Speed)}: {Speed}, {nameof(Pitch)}: {Pitch}, {nameof(Volume)}: {Volume}, {nameof(Voice)}: {Voice}";
 }


### PR DESCRIPTION
## 添加功能
- 新增 `AudioDevice` 类：用于表示音频输出设备
- 添加 `GetAudioDevices()` 静态方法：获取系统所有可用音频设备列表
- 添加 `GetDefaultAudioDeviceId()` 静态方法：获取系统默认音频设备ID
## 修改功能
- 更新 `PlayAudioAsync()` 方法：支持指定音频输出设备
- 更新 `EdgeTTSSettings` 类：添加 `AudioDeviceId` 属性
## 测试工具
- 参见：[EdgeTTSTest](https://github.com/TheDeathDragon/EdgeTTSTest)